### PR TITLE
Updated to use current api versioning system and added ability to send context

### DIFF
--- a/lib/wit.js
+++ b/lib/wit.js
@@ -16,12 +16,11 @@
 
 var request = require('request');
 var _ = require('underscore');
-var VERSION = "20141119";
+var VERSION = "201536";
 
 var getHeaders = function (access_token, others) {
     return _.extend(others || {}, {
         'Authorization': 'Bearer ' + access_token,
-        'Accept': 'application/vnd.wit.' + VERSION
     });
 };
 
@@ -32,9 +31,29 @@ var getHeaders = function (access_token, others) {
  * @param callback callback that takes 2 arguments err and the response body
  */
 var captureTextIntent = function (access_token, text, callback) {
+  captureTextIntentWithContext(access_token, text, {}, callback);
+};
+
+/**
+ * Returns the meaning extracted from the text input
+ * @param access_token your access token from your instance settings page
+ * @param text the text you want to analyze
+ * @param context json object to be passed to wit for context
+ * @param callback callback that takes 2 arguments err and the response body
+ */
+var captureTextIntentWithContext = function (access_token, text, context, callback) {
+    query_params = {'q': text, 'v': VERSION};
+    console.log(query_params)
+    if(_.size(context)){
+      _.extend(query_params, {'context': context});
+    }
+
+    console.log("query_params: ")
+    console.log(query_params)
+
     var options = {
         url: 'https://api.wit.ai/message',
-        qs: {'q': text},
+        qs: query_params,
         json: true,
         headers: getHeaders(access_token)
     };
@@ -55,8 +74,25 @@ var captureTextIntent = function (access_token, text, callback) {
  * @param callback callback that takes 2 arguments err and the response body
  */
 var captureSpeechIntent = function (access_token, stream, content_type, callback) {
+    captureSpeechIntentWithContext(access_token, stream, content_type, {}, callback);
+}
+
+/**
+ * Returns the meaning extracted from a audio stream
+ * @param access_token your access token from your instance settings page
+ * @param stream The audio stream to send over to WIT.AI
+ * @param content_type The content-type for this audio stream (audio/wav, ...)
+ * @param context json object to be passed to wit for context
+ * @param callback callback that takes 2 arguments err and the response body
+ */
+var captureSpeechIntentWithContext = function (access_token, stream, content_type, context, callback) {
+    query_params = {'v': VERSION};
+    if(_.size(context)){
+      _.extend(query_params, {'context': context});
+    }
     var options = {
         url: 'https://api.wit.ai/speech',
+        qs: query_params,
         method: 'POST',
         json: true,
         headers: getHeaders(access_token, {'Content-Type': content_type})
@@ -71,4 +107,6 @@ var captureSpeechIntent = function (access_token, stream, content_type, callback
 };
 
 module.exports.captureTextIntent = captureTextIntent;
+module.exports.captureTextIntentWithContext = captureTextIntentWithContext;
 module.exports.captureSpeechIntent = captureSpeechIntent;
+module.exports.captureSpeechIntentWithContext = captureSpeechIntent;

--- a/lib/wit.js
+++ b/lib/wit.js
@@ -16,11 +16,12 @@
 
 var request = require('request');
 var _ = require('underscore');
-var VERSION = "201536";
+var VERSION = "20150306";
 
 var getHeaders = function (access_token, others) {
     return _.extend(others || {}, {
         'Authorization': 'Bearer ' + access_token,
+        'Accept': 'application/vnd.wit.' + VERSION
     });
 };
 
@@ -42,7 +43,7 @@ var captureTextIntent = function (access_token, text, callback) {
  * @param callback callback that takes 2 arguments err and the response body
  */
 var captureTextIntentWithContext = function (access_token, text, context, callback) {
-    query_params = {'q': text, 'v': VERSION};
+    query_params = {'q': text};
     console.log(query_params)
     if(_.size(context)){
       _.extend(query_params, {'context': context});
@@ -86,13 +87,9 @@ var captureSpeechIntent = function (access_token, stream, content_type, callback
  * @param callback callback that takes 2 arguments err and the response body
  */
 var captureSpeechIntentWithContext = function (access_token, stream, content_type, context, callback) {
-    query_params = {'v': VERSION};
-    if(_.size(context)){
-      _.extend(query_params, {'context': context});
-    }
     var options = {
         url: 'https://api.wit.ai/speech',
-        qs: query_params,
+        qs: {'context': context},
         method: 'POST',
         json: true,
         headers: getHeaders(access_token, {'Content-Type': content_type})

--- a/lib/wit.js
+++ b/lib/wit.js
@@ -29,28 +29,15 @@ var getHeaders = function (access_token, others) {
  * Returns the meaning extracted from the text input
  * @param access_token your access token from your instance settings page
  * @param text the text you want to analyze
+ * @param [context] json object to be passed to wit for context
  * @param callback callback that takes 2 arguments err and the response body
  */
-var captureTextIntent = function (access_token, text, callback) {
-  captureTextIntentWithContext(access_token, text, {}, callback);
-};
-
-/**
- * Returns the meaning extracted from the text input
- * @param access_token your access token from your instance settings page
- * @param text the text you want to analyze
- * @param context json object to be passed to wit for context
- * @param callback callback that takes 2 arguments err and the response body
- */
-var captureTextIntentWithContext = function (access_token, text, context, callback) {
-    query_params = {'q': text};
-    console.log(query_params)
-    if(_.size(context)){
-      _.extend(query_params, {'context': context});
+var captureTextIntent = function (access_token, text, context, callback) {
+    if( !callback) {
+        callback = context;
+        context=undefined;
     }
-
-    console.log("query_params: ")
-    console.log(query_params)
+    query_params = {'q': text, 'context': context};
 
     var options = {
         url: 'https://api.wit.ai/message',
@@ -72,21 +59,15 @@ var captureTextIntentWithContext = function (access_token, text, context, callba
  * @param access_token your access token from your instance settings page
  * @param stream The audio stream to send over to WIT.AI
  * @param content_type The content-type for this audio stream (audio/wav, ...)
+ * @param [context] json object to be passed to wit for context
  * @param callback callback that takes 2 arguments err and the response body
  */
-var captureSpeechIntent = function (access_token, stream, content_type, callback) {
-    captureSpeechIntentWithContext(access_token, stream, content_type, {}, callback);
-}
+var captureSpeechIntent = function (access_token, stream, content_type, context, callback) {
+    if( !callback) {
+        callback = context;
+        context=undefined;
+    }
 
-/**
- * Returns the meaning extracted from a audio stream
- * @param access_token your access token from your instance settings page
- * @param stream The audio stream to send over to WIT.AI
- * @param content_type The content-type for this audio stream (audio/wav, ...)
- * @param context json object to be passed to wit for context
- * @param callback callback that takes 2 arguments err and the response body
- */
-var captureSpeechIntentWithContext = function (access_token, stream, content_type, context, callback) {
     var options = {
         url: 'https://api.wit.ai/speech',
         qs: {'context': context},
@@ -104,6 +85,4 @@ var captureSpeechIntentWithContext = function (access_token, stream, content_typ
 };
 
 module.exports.captureTextIntent = captureTextIntent;
-module.exports.captureTextIntentWithContext = captureTextIntentWithContext;
 module.exports.captureSpeechIntent = captureSpeechIntent;
-module.exports.captureSpeechIntentWithContext = captureSpeechIntent;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-wit",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "private": false,
     "homepage": "https://github.com/wit-ai/node-wit",
     "description":"Node module to request Wit.AI",

--- a/test/wit_test.js
+++ b/test/wit_test.js
@@ -28,9 +28,8 @@ describe('Wit', function () {
             var scope = nock('https://api.wit.ai/', {
                 reqheaders: {
                     'Authorization': 'Bearer 1234',
-                    'Accept': 'application/vnd.wit.20141119'
                 }
-            }).get('/message?q=set%20alarm%20tomorrow%20at%205pm')
+            }).get('/message?q=set%20alarm%20tomorrow%20at%205pm&v=201536')
                 .reply(200, wit_response);
             wit.captureTextIntent("1234", "set alarm tomorrow at 5pm", function (err, res) {
                 assert.isNull(err, "error should be undefined");
@@ -41,7 +40,7 @@ describe('Wit', function () {
         });
         it('return an error', function (done) {
             var scope = nock('https://api.wit.ai/')
-                .get('/message?q=set%20alarm%20tomorrow%20at%205pm')
+                .get('/message?q=set%20alarm%20tomorrow%20at%205pm&v=201536')
                 .reply(400, error_response);
             wit.captureTextIntent("1234", "set alarm tomorrow at 5pm", function (err, res) {
                 assert.equal(err, "Invalid response received from server: 400");
@@ -58,10 +57,9 @@ describe('Wit', function () {
             var scope = nock('https://api.wit.ai/', {
                 reqheaders: {
                     'Authorization': 'Bearer 1234',
-                    'Accept': 'application/vnd.wit.20141119',
                     'Content-Type': "audio/wav"
                 }
-            }).post('/speech')
+            }).post('/speech?v=201536')
                 .reply(200, wit_response);
             wit.captureSpeechIntent("1234", stream, "audio/wav", function (err, res) {
                 assert.isNull(err, "error should be undefined");
@@ -73,7 +71,7 @@ describe('Wit', function () {
         it('return an error', function (done) {
             var stream = fs.createReadStream(path.join(resourceDir, 'sample.wav'));
             var scope = nock('https://api.wit.ai/')
-                .post('/speech')
+                .post('/speech?v=201536')
                 .reply(404, error_response);
             wit.captureSpeechIntent("1234", stream, "audio/wav", function (err, res) {
                 assert.equal(err, "Invalid response received from server: 404");

--- a/test/wit_test.js
+++ b/test/wit_test.js
@@ -28,8 +28,9 @@ describe('Wit', function () {
             var scope = nock('https://api.wit.ai/', {
                 reqheaders: {
                     'Authorization': 'Bearer 1234',
+                    'Accept': 'application/vnd.wit.20150306'
                 }
-            }).get('/message?q=set%20alarm%20tomorrow%20at%205pm&v=201536')
+            }).get('/message?q=set%20alarm%20tomorrow%20at%205pm')
                 .reply(200, wit_response);
             wit.captureTextIntent("1234", "set alarm tomorrow at 5pm", function (err, res) {
                 assert.isNull(err, "error should be undefined");
@@ -40,7 +41,7 @@ describe('Wit', function () {
         });
         it('return an error', function (done) {
             var scope = nock('https://api.wit.ai/')
-                .get('/message?q=set%20alarm%20tomorrow%20at%205pm&v=201536')
+                .get('/message?q=set%20alarm%20tomorrow%20at%205pm')
                 .reply(400, error_response);
             wit.captureTextIntent("1234", "set alarm tomorrow at 5pm", function (err, res) {
                 assert.equal(err, "Invalid response received from server: 400");
@@ -57,9 +58,10 @@ describe('Wit', function () {
             var scope = nock('https://api.wit.ai/', {
                 reqheaders: {
                     'Authorization': 'Bearer 1234',
+                    'Accept': 'application/vnd.wit.20150306',
                     'Content-Type': "audio/wav"
                 }
-            }).post('/speech?v=201536')
+            }).post('/speech')
                 .reply(200, wit_response);
             wit.captureSpeechIntent("1234", stream, "audio/wav", function (err, res) {
                 assert.isNull(err, "error should be undefined");
@@ -71,7 +73,7 @@ describe('Wit', function () {
         it('return an error', function (done) {
             var stream = fs.createReadStream(path.join(resourceDir, 'sample.wav'));
             var scope = nock('https://api.wit.ai/')
-                .post('/speech?v=201536')
+                .post('/speech')
                 .reply(404, error_response);
             wit.captureSpeechIntent("1234", stream, "audio/wav", function (err, res) {
                 assert.equal(err, "Invalid response received from server: 404");


### PR DESCRIPTION
Previously, node-wit was using the old api versioning system where the version was set in the request headers. The API version has been updated (so nor more "DEPRICATED" warnings) and is now passed in the URI as v={version}.
Also added the ability to send a context object with the request.
