### PR TITLE
Fixes #1. Show standard npm package installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,10 @@
     ...
     ```
     
-    Add node-wit as a dependencies in your package.json
+    Install and add node-wit as a dependencies in your package.json :
     
-    ```json
-      "dependencies": {
-        "node-wit": "1.2.0"	
-      },	
+    ```bash
+    npm install --save node-wit
     ```
     
     Execute `npm install` in your current folder to fetch the dependencies


### PR DESCRIPTION
Fixes #1 
Instead of providing an example of what the 
package.json dependencies file contents will look 
like with node-wit installed, 
simply run npm install --save <package-name>
and let npm both install and add the dependency and version
to package.json file
